### PR TITLE
Updated container registry name substring

### DIFF
--- a/infra/modules/azure/container-registry/interface/outputs.tf
+++ b/infra/modules/azure/container-registry/interface/outputs.tf
@@ -1,7 +1,7 @@
 output "container_registry_name" {
   # image registry name must be globally unique, only allows alpha numeric
   # characters, and must be between 5 and 50 characters
-  value = substr(replace("${var.project_config.project_name}-${var.project_config.project_unique_id}", "/[^a-zA-Z0-9]/", ""), 0, 50)
+  value = substr(replace("${var.project_config.project_name}-${var.project_config.project_unique_id}", "/[^a-zA-Z0-9]/", ""), 0, 49)
 }
 
 output "container_registry_resource_group_name" {


### PR DESCRIPTION
## Ticket

## Changes

Changed substring character range from 0 - 50 to 0 - 49

## Context for reviewers

Ran into an error running set-up-account:
╷
│ Error: "name" cannot be longer than 50 characters: "akhealthiesterraformnavainfra84e393db7d858c5a9727e" 50
│ 
│   with module.container_registry_data[0].data.azurerm_container_registry.registry,
│   on ../modules/azure/container-registry/data/main.tf line 11, in data "azurerm_container_registry" "registry":
│   11:   name                = var.name
│ 

## Testing

Tested this locally and this error has gone away.