### PR TITLE
Don't create example service secrets by default

### DIFF
--- a/docs/infra/environment-variables-and-secrets.md
+++ b/docs/infra/environment-variables-and-secrets.md
@@ -68,7 +68,7 @@ configuration in the container definition.
 Secrets are defined in the same file that non-sensitive environment variables
 are defined, `infra/<APP_NAME>/app-config/env-config/environment_variables.tf`.
 Modify the `secrets` map to define the secrets that the application will have
-access to.  For each secret, the map key defines the environment variable name.
+access to. For each secret, the map key defines the environment variable name.
 The `manage_method` property, which can be set to `"generated"` or `"manual"`,
 defines whether or not to generate a random secret or to reference an existing
 secret that was manually created and stored. The `secret_name` property defines
@@ -95,3 +95,8 @@ locals {
 ```
 
 > ⚠️ For secrets with `manage_method = "manual"`, make sure you store the secret in Azure Key Vault *before* you try to add configure your application service with the secrets, or else the deploy will fail trying to look for a secret name that doesn't exist.
+
+Note that by default, every service+environment combination uses its own Key
+Vault. Referencing secrets that are in a shared Key Vault or that are shared
+across all environments of a service are [not supported via this configuration
+currently](https://github.com/navapbc/template-infra-azure/issues/33).

--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -18,13 +18,16 @@ locals {
   #   }
   # }
   secrets = {
-    SECRET_SAUCE = {
-      manage_method = "manual"
-      secret_name   = "secret-sauce"
-    },
-    RANDOM_SECRET = {
-      manage_method = "generated"
-      secret_name   = "random-secret"
-    },
+    # Example generated secret
+    # RANDOM_SECRET = {
+    #   manage_method = "generated"
+    #   secret_name   = "random-secret"
+    # },
+
+    # Example secret that references a manually created secret
+    # SECRET_SAUCE = {
+    #   manage_method = "manual"
+    #   secret_name   = "secret-sauce"
+    # },
   }
 }

--- a/infra/{{app_name}}/service/secrets.tf
+++ b/infra/{{app_name}}/service/secrets.tf
@@ -35,11 +35,10 @@ module "secrets" {
 
   source = "../../modules/secret"
 
-  # When generating secrets and storing them in parameter store, append the
-  # terraform workspace to the secret store path if the environment is temporary
-  # to avoid conflicts with existing environments.
-  # Don't do this for secrets that are managed manually since the temporary
-  # environments will need to share those secrets.
+  # When generating secrets and storing them, append the terraform workspace to
+  # the secret store path if the environment is temporary to avoid conflicts
+  # with existing environments. Don't do this for secrets that are managed
+  # manually since the temporary environments will need to share those secrets.
   secret_name = (each.value.manage_method == "generated" && local.is_temporary ?
     "${each.value.secret_name}-${terraform.workspace}" :
     each.value.secret_name


### PR DESCRIPTION
This aligns with AWS template behavior.

## Context for reviewers

As mentioned in the updated docs, created https://github.com/navapbc/template-infra-azure/issues/33 for a possible future improvement.

## Testing

Applying the changes to `platform-test-azure`:

<img width="1243" height="994" alt="image" src="https://github.com/user-attachments/assets/2ae75a3a-bd93-4e57-95ab-acbc59310c40" />

Will need to manually uncomment for `app` in `platform-test-azure` after these changes are deployed there.
