### PR TITLE
Fix dead link check for main.tf in set-up-network docs

### DIFF
--- a/docs/infra/set-up-network.md
+++ b/docs/infra/set-up-network.md
@@ -28,6 +28,7 @@ Before setting up the network you'll need to have:
    1. Update `network_name` for your application environments. This mapping
       ensures that each network is configured appropriately based on the
       application(s) in that network (see `local.apps_in_network` in
+      <!-- markdown-link-check-disable-next-line -->
       [/infra/networks/main.tf](/infra/networks/main.tf)). Failure to set the
       network name properly means that the network layer may not receive the
       correct application configurations (e.g., `has_database`).


### PR DESCRIPTION
## Summary
- The link to `/infra/networks/main.tf` in `set-up-network.md` is valid in instantiated repos but fails the link checker in the template repo (where it's `main.tf.jinja`)
- Uses `<!-- markdown-link-check-disable-next-line -->` inline disable, consistent with how `template-infra` handles this

## Test plan
- [ ] CI Documentation Checks passes