### PR TITLE
Add `bin/infra-admin-ids-from-group` helper script

### DIFF
--- a/bin/infra-admin-ids-from-group
+++ b/bin/infra-admin-ids-from-group
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Generate list of user IDs in given Entra Group, that can then be easily
+# copy-pasted into `infra_admins` blocks in `infra/project-config/main.tf`.
+
+set -euo pipefail
+
+group_id_or_display_name=$1
+
+readarray -t group_members < <(az ad group member list --group "${group_id_or_display_name}" | jq -c ".[]")
+
+for member in "${group_members[@]}"; do
+  object_id=$(echo "${member}" | jq -r ".id")
+  principal_name=$(echo "${member}" | jq -r ".userPrincipalName")
+
+  echo "        \"${object_id}\",             # ${principal_name}"
+done

--- a/docs/infra/set-up-azure-account.md
+++ b/docs/infra/set-up-azure-account.md
@@ -29,6 +29,9 @@ The Azure account setup process will:
   * You will ultimately want to set an `infra_admins` entry for the given
     account name, but you can do that after initial creation. Note only the
     person who runs the initial create will be able to run the update.
+    * If you have an Entra group for the admins, the
+      `bin/infra-admin-ids-from-group <GROUP_NAME>` script can provide the list
+      of IDs for easy copy-paste into the config.
 
 ## Instructions
 


### PR DESCRIPTION
## Changes

Ideally we recommend a different setup altogether[1], but until then, this could assist folks keeping the static list up to date. This could be further automated, but start simple.

[1] https://github.com/navapbc/template-infra-azure/issues/16

## Context for reviewers

This script does require Bash 4+, which is slightly different from the other bin scripts (which generally try to support ancient versions for OOTB macOS support), but given the slightly different nature for this script I don't think it's worth the effort to support old stuff.

## Testing

Ran it for `platform-test-azure`, https://github.com/navapbc/platform-test-azure/commit/736ca4834e280cdc776a588a8d324bea5c26a33a
