### PR TITLE
Add DB_AUTH_METHOD as a default environment variable with value "azure_entra"

### DIFF
--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -119,6 +119,8 @@ module "service" {
   memory                 = local.service_config.memory
   desired_instance_count = local.service_config.desired_instance_count
 
+  extra_environment_variables = local.service_config.extra_environment_variables
+
   # Note: The secrets will reference the specific hash of the current revision
   # If the secret is manually updated, you will need to re-run terraform apply
   # for the new version to be picked up and updated in the revision


### PR DESCRIPTION
## Ticket

Resolves [issues while adding new application](https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679)

## Changes

- **Wire `extra_environment_variables` into service module (`infra/{{app-name}}/service/main.tf`)
    - Without this, env vars defined in `env-config/environment-variables.tf` (e.g. `DB_AUTH_METHOD`) were silently dropped and never set in the Container App.
    -
## Context for reviewers
Fixes issues encountered while adding new application


## Testing

https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679
