### PR TITLE
Disable Terraform's default resource provider registrations

### DIFF
--- a/bin/check-registered-resource-providers
+++ b/bin/check-registered-resource-providers
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+account_id=${1:-$(./bin/current-account-id)}
+
+# Be sure the project-config outputs exist
+terraform -chdir="infra/project-config" apply -auto-approve > /dev/null
+
+project_resource_providers=$(terraform -chdir=infra/project-config output -json azure_resource_providers | jq -r '.[]' | sort)
+
+account_registered_resource_providers=$(az provider list --subscription "${account_id}" --query "[?registrationState=='Registered'].namespace" --output tsv | sort)
+
+missing_project_providers=$(comm -23 <(echo "${project_resource_providers}") <(echo "${account_registered_resource_providers}"))
+
+if [[ -z "${missing_project_providers}" ]]; then
+  echo "All project providers are registered."
+else
+  echo -e "Missing project providers:\n${missing_project_providers}"
+fi

--- a/docs/infra/set-up-azure-account.md
+++ b/docs/infra/set-up-azure-account.md
@@ -26,6 +26,23 @@ The Azure account setup process will:
     `infra/project-config/networks.tf` to the name you will use for
     `<ACCOUNT_NAME>` below, which is where shared project resources will be
     created.
+  * If you do not have permission to register Azure Resource Providers in the
+    target account take the following steps:
+    * Set `azure_resource_providers_autoenable = false` in `infra/project-config/azure_resource_providers.tf`
+    * Determine if there are resource providers that need to be registered for the project.
+      * Via CLI: run `bin/check-registered-resource-providers [subscription-id]`
+      * Via the Azure Portal:
+        * Log in to the Azure Portal
+        * Navigate to the appropriate Subscription page, then in the sidebar go
+          to Settings > Resource Providers
+        * Set the "Status" filter to "Registered"
+        * Lookup each value from `azure_resource_providers` to see if they are
+          in this registered list. Note any that are not.
+    * Provide the list of `azure_resource_providers` that are not already
+      registered to someone that _does_ have permission to register them.
+    * Depending on which providers are missing you may be able to proceed with
+      setting up the account layer, but in general you will need to wait until
+      the providers are registered.
   * You will ultimately want to set an `infra_admins` entry for the given
     account name, but you can do that after initial creation. Note only the
     person who runs the initial create will be able to run the update.

--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -52,19 +52,27 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
-  features {}
+  subscription_id = local.subscription_id
+
+  resource_provider_registrations = "none"
+  resource_providers_to_register  = module.project_config.azure_resource_providers_autoenable ? module.project_config.azure_resource_providers : []
+
   storage_use_azuread = true
 
-  subscription_id = local.subscription_id
+  features {}
 }
 
 provider "azurerm" {
-  alias = "shared"
+  alias           = "shared"
+  subscription_id = local.shared_subscription_id
 
-  features {}
+  resource_provider_registrations = "none"
+  # TODO: should we do this?
+  # resource_providers_to_register  = module.project_config.azure_resource_providers_autoenable ? module.project_config.azure_resource_providers : []
+
   storage_use_azuread = true
 
-  subscription_id = local.shared_subscription_id
+  features {}
 }
 
 module "project_config" {

--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -19,7 +19,7 @@ locals {
   # Choose the region where this infrastructure should be deployed.
   region = module.project_config.default_region
 
-  # Set project tags that will be used to tag all resources. 
+  # Set project tags that will be used to tag all resources.
   tags = merge(module.project_config.default_tags, {
     description = "Backend resources required for terraform state management and GitHub authentication."
   })
@@ -52,19 +52,27 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
-  features {}
+  subscription_id = local.subscription_id
+
+  resource_provider_registrations = "none"
+  resource_providers_to_register  = module.project_config.azure_resource_providers_autoenable ? module.project_config.azure_resource_providers : []
+
   storage_use_azuread = true
 
-  subscription_id = local.subscription_id
+  features {}
 }
 
 provider "azurerm" {
-  alias = "shared"
+  alias           = "shared"
+  subscription_id = local.shared_subscription_id
 
-  features {}
+  resource_provider_registrations = "none"
+  # TODO: should we do this?
+  # resource_providers_to_register  = module.project_config.azure_resource_providers_autoenable ? module.project_config.azure_resource_providers : []
+
   storage_use_azuread = true
 
-  subscription_id = local.shared_subscription_id
+  features {}
 }
 
 module "project_config" {

--- a/infra/accounts/main.tf
+++ b/infra/accounts/main.tf
@@ -67,8 +67,6 @@ provider "azurerm" {
   subscription_id = local.shared_subscription_id
 
   resource_provider_registrations = "none"
-  # TODO: should we do this?
-  # resource_providers_to_register  = module.project_config.azure_resource_providers_autoenable ? module.project_config.azure_resource_providers : []
 
   storage_use_azuread = true
 

--- a/infra/networks/providers.tf
+++ b/infra/networks/providers.tf
@@ -29,21 +29,24 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
-  features {}
+  subscription_id = data.external.account_ids_by_name.result[local.network_config.account_name]
+
+  resource_provider_registrations = "none"
+
   storage_use_azuread = true
 
-  resource_providers_to_register = ["Microsoft.App"]
-
-  subscription_id = data.external.account_ids_by_name.result[local.network_config.account_name]
+  features {}
 }
 
 provider "azurerm" {
-  alias = "domain"
+  alias           = "domain"
+  subscription_id = local.domain_subscription_id
 
-  features {}
+  resource_provider_registrations = "none"
+
   storage_use_azuread = true
 
-  subscription_id = local.domain_subscription_id
+  features {}
 }
 
 provider "acme" {

--- a/infra/project-config/azure_resource_providers.tf
+++ b/infra/project-config/azure_resource_providers.tf
@@ -1,0 +1,46 @@
+# https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/azure-services-resource-providers
+#
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#resource-provider-registrations
+# https://github.com/hashicorp/terraform-provider-azurerm/blob/6814cbdbf8e5a61aad6eb74567ff110b0e1fa174/internal/resourceproviders/required.go
+locals {
+  azure_resource_providers_autoenable = true
+
+  # TODO: does this comment live here or in some template-only docs?
+  # You can get a loose list of providers from existing resources with something like:
+  #
+  #   az resource list | jq -r '.[].type' | sed "s|/.*||" | sort | uniq
+  #
+  azure_resource_providers = [
+    # These are for Azure Resource Manageer itself and registered by default in a Subscription
+    # TODO: should we include these? can we (does attempting to register even work)?
+    # "Microsoft.Authorization",
+    # "Microsoft.Resources",
+
+    # Azure Container Apps
+    "Microsoft.App",
+
+    # Azure Container Registry
+    "Microsoft.ContainerRegistry",
+
+    # Azure Database for PostgreSQL
+    "Microsoft.DBforPostgreSQL",
+
+    # Azure Monitor - data collection rules and endpoints
+    "microsoft.insights",
+
+    # Azure Key Vault - vaults for storing application secrets and TLS certificates
+    "Microsoft.KeyVault",
+
+    # Managed identities for Azure resources - User Assigned Identities
+    "Microsoft.ManagedIdentity",
+
+    # Networking items - Application Gateway, NAT Gateway, Azure DNS, Public IP Address, Virtual Network, Private Endpoint, Network Watcher, Network Security Group, Load Balancer
+    "Microsoft.Network",
+
+    # Azure Monitor - workspaces
+    "Microsoft.OperationalInsights",
+
+    // Storage accounts - for Terraform state and various data needs
+    "Microsoft.Storage",
+  ]
+}

--- a/infra/project-config/azure_resource_providers.tf
+++ b/infra/project-config/azure_resource_providers.tf
@@ -5,10 +5,9 @@
 locals {
   azure_resource_providers_autoenable = true
 
-  # TODO: does this comment live here or in some template-only docs?
-  # You can get a loose list of providers from existing resources with something like:
+  # You can get a loose list of providers from existing resources with:
   #
-  #   az resource list | jq -r '.[].type' | sed "s|/.*||" | sort | uniq
+  #   az resource list | jq -r '.[].type' | sed "s|/.*||" | sort -u
   #
   azure_resource_providers = [
     # These are for Azure Resource Manageer itself and registered by default in a Subscription
@@ -25,6 +24,9 @@ locals {
     # Azure Database for PostgreSQL
     "Microsoft.DBforPostgreSQL",
 
+    # Azure Event Grid - for actions based on Storage account events
+    "Microsoft.EventGrid",
+
     # Azure Monitor - data collection rules and endpoints
     "microsoft.insights",
 
@@ -40,7 +42,7 @@ locals {
     # Azure Monitor - workspaces
     "Microsoft.OperationalInsights",
 
-    // Storage accounts - for Terraform state and various data needs
+    # Storage accounts - for Terraform state and various data needs
     "Microsoft.Storage",
   ]
 }

--- a/infra/project-config/azure_resource_providers.tf
+++ b/infra/project-config/azure_resource_providers.tf
@@ -10,10 +10,10 @@ locals {
   #   az resource list | jq -r '.[].type' | sed "s|/.*||" | sort -u
   #
   azure_resource_providers = [
-    # These are for Azure Resource Manageer itself and registered by default in a Subscription
-    # TODO: should we include these? can we (does attempting to register even work)?
-    # "Microsoft.Authorization",
-    # "Microsoft.Resources",
+    # These are for Azure Resource Manager itself and should be registered by
+    # default in a Subscription, but included here for explicit context
+    "Microsoft.Authorization",
+    "Microsoft.Resources",
 
     # Azure Container Apps
     "Microsoft.App",

--- a/infra/project-config/outputs.tf
+++ b/infra/project-config/outputs.tf
@@ -67,3 +67,13 @@ output "project_unique_id" {
 output "infra_admins" {
   value = local.infra_admins
 }
+
+output "azure_resource_providers" {
+  description = "Azure resource providers that this project uses"
+  value       = local.azure_resource_providers
+}
+
+output "azure_resource_providers_autoenable" {
+  description = "Whether or not to have the azurerm Terraform provider attempt to automatically enable the required resource providers"
+  value       = local.azure_resource_providers_autoenable
+}

--- a/infra/{{app_name}}/database/main.tf
+++ b/infra/{{app_name}}/database/main.tf
@@ -40,6 +40,10 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
+  subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
+
+  resource_provider_registrations = "none"
+
   storage_use_azuread = true
   use_oidc            = true
 
@@ -48,8 +52,6 @@ provider "azurerm" {
       restart_server_on_configuration_value_change = false
     }
   }
-
-  subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
 }
 
 module "project_config" {

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -44,21 +44,26 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
-  use_oidc = true
-  features {}
-
   subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
+
+  resource_provider_registrations = "none"
+
+  use_oidc = true
+
+  features {}
 }
 
 provider "azurerm" {
   alias = "domain"
-
-  use_oidc = true
-  features {}
-
   # fall back to current subscription so provider can be initialized, but we
   # won't use it if hosted_zone_subscription_id is not defined
   subscription_id = local.hosted_zone_subscription_id != null ? local.hosted_zone_subscription_id : data.external.account_ids_by_name.result[local.environment_config.account_name]
+
+  resource_provider_registrations = "none"
+
+  use_oidc = true
+
+  features {}
 }
 
 module "project_config" {

--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -44,25 +44,28 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
+  subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
+
+  resource_provider_registrations = "none"
+
   use_oidc            = true
   storage_use_azuread = true
 
   features {}
-
-  subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
 }
 
 provider "azurerm" {
   alias = "domain"
+  # fall back to current subscription so provider can be initialized, but we
+  # won't use it if hosted_zone_subscription_id is not defined
+  subscription_id = local.hosted_zone_subscription_id != null ? local.hosted_zone_subscription_id : data.external.account_ids_by_name.result[local.environment_config.account_name]
+
+  resource_provider_registrations = "none"
 
   use_oidc            = true
   storage_use_azuread = true
 
   features {}
-
-  # fall back to current subscription so provider can be initialized, but we
-  # won't use it if hosted_zone_subscription_id is not defined
-  subscription_id = local.hosted_zone_subscription_id != null ? local.hosted_zone_subscription_id : data.external.account_ids_by_name.result[local.environment_config.account_name]
 }
 
 module "project_config" {


### PR DESCRIPTION
## Ticket

Resolves https://github.com/navapbc/template-infra-azure/issues/28

## Changes

Maintain an explicit list of resource providers (potentially) used by the
project, similar to the `aws_services.tf` file in the AWS template. This list
can be used to attempt to automatically register the required providers as a
part of the account layer (the default behavior), or serve as a artifact to hand
off to IT admins to enable for the out-of-band (set
`azure_resource_providers_autoenable=false`).

In the future, the list could potentially be broken down by layer, for even more
targeted enablement. But as they only need to be enabled once per Subscription,
just starting with a single list as a part of the account layer.

Also slightly reformat all the provider blocks to put the parameters in the same
order.

## Testing

Tested against `platform-test-azure`'s `dev` Subscription, cleaning up the registered provider list manually, and running infra update commands at each layer. Not a perfect test of standing up a fresh subscription, but gives reasonable confidence this is the list of providers needed for current functionality.