### PR TITLE
Resolves a race condition during VNet creation

### DIFF
--- a/infra/networks/main.tf.jinja
+++ b/infra/networks/main.tf.jinja
@@ -124,6 +124,8 @@ module "network" {
 
   container_registry_id   = local.container_registry_config.registry_id
   container_registry_name = local.container_registry_config.registry_name
+
+  depends_on = [azurerm_resource_group.network]
 }
 
 module "certificate_store" {


### PR DESCRIPTION
## Ticket

Resolves an issue where Terraform attempts to create the VNet before the resource group creation has completed when adding a new application.

## Changes
Added `depends_on = [azurerm_resource_group_network]` to module `network` to prevent the VNet data source   from failing to read the resource group before it's created.

## Context for reviewers
When creating a new VNet, an intermittent error occurs where the VNet creation process queries a resource group that is still being provisioned. This change ensures the VNet data source does not attempt to read the resource group before it is fully created.

## Testing

https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679
