### PR TITLE
Fix Key Vault name truncation resulting in a trailing hyphen

### DIFF
--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -7,6 +7,7 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+    DB_AUTH_METHOD = "azure_entra"
   }
 
   # Configuration for secrets
@@ -26,5 +27,9 @@ locals {
       manage_method = "generated"
       secret_name   = "random-secret"
     },
+    SECRET_KEY_BASE = {
+      manage_method = "generated"
+      secret_name   = "secret-key-base"
+    }
   }
 }

--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -7,7 +7,6 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
-    DB_AUTH_METHOD = "azure_entra"
   }
 
   # Configuration for secrets
@@ -27,9 +26,5 @@ locals {
       manage_method = "generated"
       secret_name   = "random-secret"
     },
-    SECRET_KEY_BASE = {
-      manage_method = "generated"
-      secret_name   = "secret-key-base"
-    }
   }
 }

--- a/infra/{{app_name}}/service/secrets.tf
+++ b/infra/{{app_name}}/service/secrets.tf
@@ -1,6 +1,6 @@
 locals {
   # this must be globally unique
-  vault_name                = substr("${local.service_config.service_name}-${local.location}-${module.project_config.project_unique_id}", 0, 24)
+  vault_name                = trimsuffix(substr("${local.service_config.service_name}-${local.location}-${module.project_config.project_unique_id}", 0, 24), "-")
   vault_resource_group_name = "${local.service_config.service_name}-secrets"
 
   key_vault_id = local.is_temporary ? data.azurerm_key_vault.vault[0].id : module.secret_store[0].key_vault_id


### PR DESCRIPTION
## Changes

Wrap vault_name substr() with trimsuffix() to prevent trailing hyphen when project_unique_id is empty or causes a 24-char boundary cut

## Context for reviewers
Resolves an issue where Key Vault name generation can produce a trailing hyphen—either due to an empty project_unique_id variable or truncation at the 24-character limit—resulting in Azure validation errors.

## Testing

https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679