### PR TITLE
add DB_AUTH_METHOD as a default env. variable with value "azure_entra"

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -14,6 +14,14 @@ locals {
     { name : "PORT", value : tostring(var.container_port) },
     { name : "IMAGE_TAG", value : var.image_tag },
     { name : "AZURE_CLIENT_ID", value : azurerm_user_assigned_identity.app.client_id },
+
+    # Resource Identifier URI (audience) used when requesting an access token from
+    # MS Entra ID for authenticating to PostgreSQL using Azure AD Auth.
+    # Different Azure DB services have different resource URIs, consult documentation
+    # for the specific service being used. For Azure Database for PostgreSQL,
+    # the resource URI is "https://ossrdbms-aad.database.windows.net"
+    { name : "AZURE_DB_RESOURCE_URI", value : "https://ossrdbms-aad.database.windows.net" },
+    { name : "DB_AUTH_METHOD", value : "azure_entra" },
   ]
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },

--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -7,6 +7,9 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
+
+    # Informs the application to use Azure Entra authentication for the database
+    DB_AUTH_METHOD = "azure_entra"
   }
 
   # Configuration for secrets

--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -7,9 +7,6 @@ locals {
     # WORKER_THREADS_COUNT    = 4
     # LOG_LEVEL               = "info"
     # DB_CONNECTION_POOL_SIZE = 5
-
-    # Informs the application to use Azure Entra authentication for the database
-    DB_AUTH_METHOD = "azure_entra"
   }
 
   # Configuration for secrets


### PR DESCRIPTION
## Ticket

Resolves issues while [adding Rails App](https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679)

## Changes

Add DB_AUTH_METHOD = "azure_entra" as default environment variable to inform the application to use Azure Entra authentication for the database

## Context for reviewers

Applications such as the Rails template can use AWS IAM DB Auth when deployed in AWS, or Azure Entra DB Auth when deployed in Azure. Setting the DB_AUTH_METHOD environment variable by default allows deployed applications to determine which database authentication method to use based on the target infrastructure.

## Testing
https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679
