### PR TITLE
Add secrets env var SECRET_KEY_BASE required by rails app

### DIFF
--- a/infra/{{app_name}}/app-config/env-config/environment-variables.tf
+++ b/infra/{{app_name}}/app-config/env-config/environment-variables.tf
@@ -26,5 +26,9 @@ locals {
       manage_method = "generated"
       secret_name   = "random-secret"
     },
+    SECRET_KEY_BASE = {
+      manage_method = "generated"
+      secret_name   = "secret-key-base"
+    }
   }
 }


### PR DESCRIPTION
## Ticket

Resolves [issues while adding new application](https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679)

## Changes

- **update env-config secrets to add SECRET_KEY_BASE default environment variable** 

## Context for reviewers
When adding an App Rails application that uses the `template-application-rails`, the application failed on startup expecting environment variable SECRET_KEY_BASE.  This environment variables is set in the `template-infra` but not in this infra template.


## Testing

https://github.com/navapbc/platform-test-azure/pull/22#issue-4197633679
