### PR TITLE
fix: preserve original Host via X-Forwarded-Host in Application Gateway to prevent redirect and CSRF validation errors

### DIFF
--- a/infra/modules/service/application_gateway.tf
+++ b/infra/modules/service/application_gateway.tf
@@ -223,11 +223,6 @@ resource "azurerm_application_gateway" "service" {
         header_name  = "X-Forwarded-Host"
         header_value = "{var_host}"
       }
-
-      request_header_configuration {
-        header_name  = "X-Forwarded-Proto"
-        header_value = "https"
-      }
     }
   }
 

--- a/infra/modules/service/application_gateway.tf
+++ b/infra/modules/service/application_gateway.tf
@@ -20,6 +20,7 @@ locals {
   http_to_https_redirect_configuration_name = "${local.gateway_resource_prefix}-rdrcfg"
   ssl_cert_name                             = "${local.gateway_resource_prefix}-ssl-cert"
   backend_probe_name                        = "${local.gateway_resource_prefix}-be-probe"
+  rewrite_rule_set_name                     = "${local.gateway_resource_prefix}-rewrite-rules"
 
   # TODO if using IP Address to the environment? Would not be needed if the backend_address_pool.fqdns is set
   backend_host_name = azurerm_container_app.service.ingress[0].fqdn
@@ -142,6 +143,8 @@ resource "azurerm_application_gateway" "service" {
     port                  = 443
     protocol              = "Https"
     # request_timeout       = 60
+
+    pick_host_name_from_backend_address = false
     # TODO if using IP Address to the environment? Would not be needed if the backend_address_pool.fqdns is set
     host_name  = local.backend_host_name
     probe_name = local.backend_probe_name
@@ -209,6 +212,25 @@ resource "azurerm_application_gateway" "service" {
     redirect_configuration_name = local.http_to_https_redirect_configuration_name
   }
 
+  rewrite_rule_set {
+    name = local.rewrite_rule_set_name
+
+    rewrite_rule {
+      name          = "forward-original-host"
+      rule_sequence = 100
+
+      request_header_configuration {
+        header_name  = "X-Forwarded-Host"
+        header_value = "{var_host}"
+      }
+
+      request_header_configuration {
+        header_name  = "X-Forwarded-Proto"
+        header_value = "https"
+      }
+    }
+  }
+
   request_routing_rule {
     name                       = local.https_request_routing_rule_name
     priority                   = 1
@@ -216,6 +238,7 @@ resource "azurerm_application_gateway" "service" {
     http_listener_name         = local.https_listener_name
     backend_address_pool_name  = local.backend_address_pool_name
     backend_http_settings_name = local.http_setting_name
+    rewrite_rule_set_name      = local.rewrite_rule_set_name
   }
 
   depends_on = [azurerm_public_ip.pip_v4[0]]


### PR DESCRIPTION
## Changes

Add a rewrite rule set that captures the original client Host into X-Forwarded-Host before the Host header is rewritten, so Rails uses the public URL for redirect_to and CSRF origin validation.

## Context for reviewers

Azure Application Gateway sets 'Host' http header to the Container App FQDN on backend connections, causing Rails application redirects to use the internal Container App FQDN instead of the public application URL.  This also causes CSRF request origin validation failures.

<img width="1796" height="1128" alt="image" src="https://github.com/user-attachments/assets/b40c1626-c159-4e52-a009-da018ab6c38d" />


## Testing

[platform-test-azure change](https://github.com/navapbc/platform-test-azure/pull/22/changes/c1b3a5e42048ac858c3a4a1403922bd7a26f2756) URL:  https://app-rails.devcentral.platform-test-azure.navateam.com/users/account

AK OSCER URL with the changes: https://akhr1.dev.oscer-azure.navateam.com/