### PR TITLE
Fix `zones_by_provider` output in `private-endpoint-dns-refs` module

### DIFF
--- a/infra/modules/azure/private-endpoint-dns-refs/main.tf
+++ b/infra/modules/azure/private-endpoint-dns-refs/main.tf
@@ -78,5 +78,5 @@ output "zones_by_resource_type" {
 }
 
 output "zones_by_provider" {
-  value = local.zones_by_resource_type
+  value = local.zones_by_provider
 }


### PR DESCRIPTION
It's not used by anything at the moment, but fix the typo.

## Testing

Just the CI.