### PR TITLE
set min-tls-version on `az storage account create` call for backend storage   

### DIFF
--- a/bin/set-up-account
+++ b/bin/set-up-account
@@ -101,6 +101,7 @@ if [[ ${storage_account_not_exists} == "true" ]]; then
         --kind StorageV2 \
         --sku Standard_GRS \
         --https-only true \
+        --min-tls-version TLS1_2 \
         --encryption-key-type-for-queue "Account" \
         --encryption-key-type-for-table "Account"
     echo "${green}""Storage account created""${restore}"


### PR DESCRIPTION
## Ticket

Resolves #58 

## Changes

added `--min-tls-version TLS1_2` to `az` storage account create in `/bin/set-up-account`

## Context for reviewers

TLS versions earlier than 1.2 are deprecated, and some clients enforce a minimum TLS 1.2 requirement for Azure API calls through subscription-level policies.

This resolves the error:

"TLS and SSL must be enabled for all resources without encryption in transit"

which occurs when clients enforce minimum TLS 1.2 version requirements through Azure Landing Zone policies.

<img width="1178" height="205" alt="image" src="https://github.com/user-attachments/assets/f84bd0dd-1d54-435f-9105-42b50c61fd0f" />

## Testing
- After setting --min-tls-version TLS1_2, the storage account was created successfully without errors.
