### PR TITLE
Use Microsoft Entra ID for Terraform auth to Storage accounts

### DIFF
--- a/infra/{{app_name}}/service/main.tf
+++ b/infra/{{app_name}}/service/main.tf
@@ -44,7 +44,9 @@ data "external" "account_ids_by_name" {
 }
 
 provider "azurerm" {
-  use_oidc = true
+  use_oidc            = true
+  storage_use_azuread = true
+
   features {}
 
   subscription_id = data.external.account_ids_by_name.result[local.environment_config.account_name]
@@ -53,7 +55,9 @@ provider "azurerm" {
 provider "azurerm" {
   alias = "domain"
 
-  use_oidc = true
+  use_oidc            = true
+  storage_use_azuread = true
+
   features {}
 
   # fall back to current subscription so provider can be initialized, but we


### PR DESCRIPTION
This fixes managing created resources and matches all other modules with storage needs.

## Testing

Running `make infra-update-app-service ENVIRONMENT=dev APP_NAME=app` in `platform-test-azure`.

Before:

<img width="3840" height="1389" alt="image" src="https://github.com/user-attachments/assets/1db5b41a-3f50-4d0a-86b0-5cb75eb6c8a2" />

After:

<img width="3840" height="1389" alt="image" src="https://github.com/user-attachments/assets/e3350c2b-f292-4ebe-b607-c815ddfc30e0" />

(the account is getting recreated as apparently the resources created there to test do not match the code that got merged and so on, but the point is Terraform can access the resource and _make a plan_ in the first place)
