### PR TITLE
Fix the Log Analytics Workspace lookup for service storage feature

### DIFF
--- a/infra/{{app_name}}/service/storage.tf
+++ b/infra/{{app_name}}/service/storage.tf
@@ -5,7 +5,7 @@ locals {
 data "azurerm_log_analytics_workspace" "logs" {
   count = module.app_config.has_blob_storage && !local.is_temporary ? 1 : 0
 
-  name                = "subscription-logs"
+  name                = "logs"
   resource_group_name = module.network.resource_group_name
 }
 


### PR DESCRIPTION
Things in the network should be using the network workspace, which is also the resource group we are already attempting to look up the workspace in.

## Testing

Running `make infra-update-app-service ENVIRONMENT=dev APP_NAME=app` in `platform-test-azure`.

Before:

<img width="2272" height="359" alt="image" src="https://github.com/user-attachments/assets/b7bc2768-b7bd-4b80-8f7b-abc4f35e88ae" />

After:

<img width="3840" height="1057" alt="image" src="https://github.com/user-attachments/assets/5cd9bed4-8d71-4e59-aa30-a86f611e669d" />
