### PR TITLE
Prefix workspace to storage account name in service storage setup

### DIFF
--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_storage_account" "storage" {
   blob_properties {
     versioning_enabled            = !var.is_temporary
     change_feed_enabled           = !var.is_temporary
-    change_feed_retention_in_days = var.is_temporary ? 1 : 90
+    change_feed_retention_in_days = var.is_temporary ? null : 90
     last_access_time_enabled      = true
 
     delete_retention_policy {

--- a/infra/{{app_name}}/service/storage.tf
+++ b/infra/{{app_name}}/service/storage.tf
@@ -1,5 +1,6 @@
 locals {
-  storage_config = local.environment_config.storage_config
+  storage_config       = local.environment_config.storage_config
+  storage_account_name = substr("${local.prefix}${local.storage_config.account_name}", 0, 24)
 }
 
 data "azurerm_log_analytics_workspace" "logs" {
@@ -13,7 +14,7 @@ module "storage" {
   count  = module.app_config.has_blob_storage ? 1 : 0
   source = "../../modules/storage"
 
-  name                    = local.storage_config.account_name
+  name                    = local.storage_account_name
   resource_group_name     = local.is_temporary ? local.resource_group_name : azurerm_resource_group.service[0].name
   resource_group_location = local.location
   container_name          = local.storage_config.container_name

--- a/infra/{{app_name}}/service/storage.tf
+++ b/infra/{{app_name}}/service/storage.tf
@@ -1,6 +1,6 @@
 locals {
   storage_config       = local.environment_config.storage_config
-  storage_account_name = substr("${local.prefix}${local.storage_config.account_name}", 0, 24)
+  storage_account_name = substr("${replace(lower("${local.prefix}"), "/[^a-z0-9]/", "")}${local.storage_config.account_name}", 0, 24)
 }
 
 data "azurerm_log_analytics_workspace" "logs" {


### PR DESCRIPTION
The storage feature is broken in temporary environments, thus breaking the infra
tests. To fix:

- Add the workspace name to storage account, matching the behavior in the AWS
  template. Though the constraints are a little different in Azure, needing to
  limit to only lowercase letters and numbers, and a total length of 24
  characters.
- Set `change_feed_retention_in_days = null` for temporary environments, instead
  of `1`, in order to have `change_feed_enabled = false`.

## Testing

Attempting to run infra tests for `app` in `platform-test-azure`, before:

```
[01](https://github.com/navapbc/platform-test-azure/actions/runs/28404010213/job/84162729763#step:6:1104)
  TestService 2026-06-29T21:36:49Z logger.go:79: │ Error: a resource with the ID "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.Storage/storageAccounts/appdevst7762be14" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_storage_account" for more information
  TestService 2026-06-29T21:36:49Z logger.go:79: │ 
  TestService 2026-06-29T21:36:49Z logger.go:79: │   with module.storage[0].azurerm_storage_account.storage,
  TestService 2026-06-29T21:36:49Z logger.go:79: │   on ../../modules/storage/main.tf line 1, in resource "azurerm_storage_account" "storage":
  TestService 2026-06-29T21:36:49Z logger.go:79: │    1: resource "azurerm_storage_account" "storage" {
  TestService 2026-06-29T21:36:49Z logger.go:79: │ 
  TestService 2026-06-29T21:36:49Z logger.go:79: ╵
  TestService 2026-06-29T21:36:49Z retry.go:168: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; ╷
  │ Error: a resource with the ID "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.Storage/storageAccounts/appdevst7762be14" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_storage_account" for more information
  │ 
  │   with module.storage[0].azurerm_storage_account.storage,
  │   on ../../modules/storage/main.tf line 1, in resource "azurerm_storage_account" "storage":
  │    1: resource "azurerm_storage_account" "storage" {
  │ 
  ╵}
      apply.go:65: 
          	Error Trace:	/home/runner/go/pkg/mod/github.com/gruntwork-io/terratest@v1.0.1/modules/terraform/apply.go:65
          	            				/home/runner/go/pkg/mod/github.com/gruntwork-io/terratest@v1.0.1/modules/terraform/apply.go:57
          	            				/home/runner/work/platform-test-azure/platform-test-azure/infra/test/infra_test.go:52
          	Error:      	Received unexpected error:
          	            	FatalError{Underlying: error while running command: exit status 1; ╷
          	            	│ Error: a resource with the ID "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.Storage/storageAccounts/appdevst7762be14" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_storage_account" for more information
          	            	│ 
          	            	│   with module.storage[0].azurerm_storage_account.storage,
          	            	│   on ../../modules/storage/main.tf line 1, in resource "azurerm_storage_account" "storage":
          	            	│    1: resource "azurerm_storage_account" "storage" {
          	            	│ 
          	            	╵}
          	Test:       	TestService
```

After:

https://github.com/navapbc/platform-test-azure/pull/25

https://github.com/navapbc/platform-test-azure/actions/runs/28822328006/job/85477602617?pr=25