### PR TITLE
Fix: Don't create custom domain resources when manage_dns is set to false

### DIFF
--- a/infra/modules/service/dns.tf
+++ b/infra/modules/service/dns.tf
@@ -46,7 +46,7 @@ resource "azurerm_dns_cname_record" "service" {
 resource "azurerm_container_app_custom_domain" "service" {
   provider = azurerm.domain
 
-  count = local.should_configure_domain_name && !local.use_application_gateway ? 1 : 0
+  count = var.manage_dns && local.should_configure_domain_name && !local.use_application_gateway ? 1 : 0
 
   name                     = trimsuffix(trimprefix(azurerm_dns_txt_record.service[0].fqdn, "asuid."), ".")
   container_app_id         = azurerm_container_app.service.id
@@ -61,7 +61,7 @@ resource "azurerm_container_app_custom_domain" "service" {
 
 # https://github.com/hashicorp/terraform-provider-azurerm/issues/27362#issuecomment-2407827846
 resource "null_resource" "custom_domain_and_managed_certificate" {
-  count = local.should_configure_domain_name && !local.use_application_gateway ? 1 : 0
+  count = var.manage_dns && local.should_configure_domain_name && !local.use_application_gateway ? 1 : 0
 
   provisioner "local-exec" {
     command = "az containerapp hostname bind --hostname ${local.custom_fqdn} --resource-group ${var.resource_group_name} --name ${azurerm_container_app.service.name} --environment ${data.azurerm_container_app_environment.env.id} --subscription ${data.azurerm_subscription.current.subscription_id} --validation-method CNAME"


### PR DESCRIPTION
## Ticket

When manage_dns = false, the TXT record isn't created, but the custom domain and null_resource are still trying to create and reference it. This PR gates all custom domain resources with var.manage_dns in the same way the TXT record is.

Issue found while investigating:

<img width="938" height="173" alt="image" src="https://github.com/user-attachments/assets/174c6d02-81a9-4aa4-b22b-30bd4c6b6cb6" />

## Changes

Added a gate to the creation of custom domain and null_resource, so it is not created when var.manage_dns = false - same gate already exist for the DNS TXT record `azurerm_dns_txt_record.service`

## Testing

### Before

<img width="938" height="173" alt="image" src="https://github.com/user-attachments/assets/174c6d02-81a9-4aa4-b22b-30bd4c6b6cb6" />

### After
Environment with `manage_dns=false` -> No Domain was provisioned successfully:

<img width="1671" height="117" alt="image" src="https://github.com/user-attachments/assets/561079de-5ae2-44ae-ada4-ca09398fb0b5" />

