### PR TITLE
storage: Update deprecated `source_arm_resource_id` property name

### DIFF
--- a/infra/modules/storage/events.tf
+++ b/infra/modules/storage/events.tf
@@ -3,9 +3,9 @@
 # to Event Grid. Subscribers can then subscribe to these events.
 # Azure analog of aws_s3_bucket_notification with eventbridge = true in AWS template.
 resource "azurerm_eventgrid_system_topic" "storage" {
-  name                   = "${var.name}-storage-events"
-  resource_group_name    = var.resource_group_name
-  location               = var.resource_group_location
-  source_arm_resource_id = azurerm_storage_account.storage.id
-  topic_type             = "Microsoft.Storage.StorageAccounts"
+  name                = "${var.name}-storage-events"
+  resource_group_name = var.resource_group_name
+  location            = var.resource_group_location
+  source_resource_id  = azurerm_storage_account.storage.id
+  topic_type          = "Microsoft.Storage.StorageAccounts"
 }


### PR DESCRIPTION
The `arm_` part has been removed from a few property names in `azurerm_eventgrid_system_topic` in v4.40.0 of the provider[1]. The template currently requires v4.79.x, so we can use the non-deprecated name.

[1] https://github.com/hashicorp/terraform-provider-azurerm/commit/6497dca3b46de7c57da2a0a355b562044d7450b0

## Testing

`make infra-update-app-service ENVIRONMENT=dev APP_NAME=app` in `platformt-test`.

Before:

<img width="1148" height="546" alt="image" src="https://github.com/user-attachments/assets/40d1251a-a291-48c4-9462-e125db63a35e" />


After:

<img width="1148" height="383" alt="image" src="https://github.com/user-attachments/assets/a7ac7d5e-997a-417d-a852-6ecdbcf1299d" />

The tfsec CI failure is unrelated.