### PR TITLE
Ensure service can access secrets before updating the service

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -58,11 +58,14 @@ resource "azurerm_container_app" "service" {
   workload_profile_name        = "Consumption"
 
   # Other roles are also required, but that list may be dynamic/would require
-  # more work to track super accurately, so just one one of the roles, which
-  # generally gets things delayed/ordered correctly. If you happen to encounter
-  # deploy errors around roles not existing, should be able to just retry the
-  # deploy.
-  depends_on = [azurerm_role_assignment.app_cr]
+  # more work to track super accurately, so just reference the roles/assignments
+  # that are readily accessible, which generally gets things delayed/ordered
+  # correctly. If you happen to encounter deploy errors around roles not
+  # existing, should be able to just retry the deploy.
+  depends_on = [
+    azurerm_role_assignment.app_cr,
+    azurerm_role_assignment.app_secrets
+  ]
 
   identity {
     type         = "UserAssigned"
@@ -152,7 +155,10 @@ resource "azurerm_container_app_job" "service_job" {
   location                     = var.resource_group_location
   workload_profile_name        = "Consumption"
 
-  depends_on = [azurerm_role_assignment.migrator_cr]
+  depends_on = [
+    azurerm_role_assignment.migrator_cr,
+    azurerm_role_assignment.migrator_secrets
+  ]
 
   identity {
     type         = "UserAssigned"


### PR DESCRIPTION
The secrets are directly referenced in the service definition and
Container Apps needs to be able to access them in order to update.

Previously, if you added a new secret to the service env-config, then
attempted to run database migrations, you encounter an error like:

> Resource Group Name: "<rg name>" Job Name: "<service job>") performing
> CreateOrUpdate: unexpected status 400 (400 Bad Request) with error:
> InvalidParameterValueInContainerTemplate: The following field(s) are
> either invalid or missing. Field 'configuration.secrets' is invalid
> with details: 'Invalid value: "<secret name>": Unable to get value
> using Managed identity <app id> for secret <secret name>

Because the role assignments to access the secrets in
`modules/service/access_control.tf` were not included in the
`/bin/run-database-migrations` target of
`-target=module.service.azurerm_container_app_job.service_job`. By
adding the secret role assignments to the `depends_on` of
`container_app_job.service_job`, the `-target` will create/update the
role assignments before attempting to update the service.

We could alternatively explicitly order resource creation in
`/bin/run-database-migrations` for this particular error, but the
situation can come up outside of just the database migrations. Since the
secret role assignments are readily accessible, just include them to
make things more automatic.

## Testing

Error before after adding new secrets: https://github.com/navapbc/platform-test-azure/actions/runs/30038087740/job/89312982466

After changes running `bin/run-database-migrations` against same changes:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # module.secrets["RANDOM_SECRET"].azurerm_key_vault_secret.secret[0] will be created
  + resource "azurerm_key_vault_secret" "secret" {
      + id                      = (known after apply)
      + key_vault_id            = "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-secrets/providers/Microsoft.KeyVault/vaults/app-dev-eastus-938b915e7"
      + name                    = "random-secret"
      + resource_id             = (known after apply)
      + resource_versionless_id = (known after apply)
      + value                   = (sensitive value)
      + value_wo                = (write-only attribute)
      + version                 = (known after apply)
      + versionless_id          = (known after apply)
    }

  # module.secrets["RANDOM_SECRET"].random_password.secret[0] will be created
  + resource "random_password" "secret" {
      + bcrypt_hash      = (sensitive value)
      + id               = (known after apply)
      + length           = 64
      + lower            = true
      + min_lower        = 0
      + min_numeric      = 0
      + min_special      = 0
      + min_upper        = 0
      + number           = true
      + numeric          = true
      + override_special = "!#$%&*()-_=+[]{}<>:?"
      + result           = (sensitive value)
      + special          = true
      + upper            = true
    }

  # module.service.azurerm_container_app_job.service_job will be updated in-place
  ~ resource "azurerm_container_app_job" "service_job" {
        id                           = "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.App/jobs/app-dev-job"
        name                         = "app-dev-job"
        tags                         = {}
        # (8 unchanged attributes hidden)

      + secret {
          # At least one attribute in this block is (or was) sensitive,                                                                                                                              
          # so its contents will not be displayed.                                                                                                                                                                  
        }                                                                                                                                                                                                           
      + secret {                                                                                                                                                                                                    
          # At least one attribute in this block is (or was) sensitive,                                                                                                                                             
          # so its contents will not be displayed.                                                                                                                                                                  
        }                                                                                                                                                                                                           
                                                                                                                                                                                                                    
      ~ template {                                                                                                                                                                                                  
          ~ container {                                                                                                                                                                                             
                name              = "app-dev"                                                                                                                                                                       
                # (6 unchanged attributes hidden)                                                                                                                                                                   
                                                                                                                                                                                                                    
              + env {                                                                                                                                                                                               
                  + name        = "RANDOM_SECRET"                                                                                                                                                                   
                  + secret_name = "random-secret"                                                                                                                                                                   
                }                                                                                                                                                                                                   
              + env {                                                                                                                                                                                               
                  + name        = "SECRET_SAUCE"                                                                                                                                                                    
                  + secret_name = "secret-sauce"                                                                                                                                                                    
                }                                                                                                                                                                                                   
                                                                                                                                                                                                                    
                # (10 unchanged blocks hidden)                                                                                                                                                                      
            }                                                                                                                                                                                                       
        }                                                                                                                                                                                                           
                                                                                                                                                                                                                    
        # (3 unchanged blocks hidden)                                                                                                                                                                               
    }                                                                                                                                                                                                               
                                                                                                                                                                                                                    
  # module.service.azurerm_role_assignment.migrator_secrets["RANDOM_SECRET"] will be created                                                                                                                        
  + resource "azurerm_role_assignment" "migrator_secrets" {                                                                                                                                                         
      + condition_version                = (known after apply)                                                                                                                                                      
      + id                               = (known after apply)                                                                                                                                                      
      + name                             = (known after apply)
      + principal_id                     = "96f700aa-6597-45ea-8dd6-2ce2a26f05e0"
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Key Vault Secrets User"
      + scope                            = (known after apply)
      + skip_service_principal_aad_check = false
    }

  # module.service.azurerm_role_assignment.migrator_secrets["SECRET_SAUCE"] will be created
  + resource "azurerm_role_assignment" "migrator_secrets" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = "96f700aa-6597-45ea-8dd6-2ce2a26f05e0"
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Key Vault Secrets User"
      + scope                            = "/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-secrets/providers/Microsoft.KeyVault/vaults/app-dev-eastus-938b915e7/secrets/secret-sauce"
      + skip_service_principal_aad_check = false
    }
Plan: 4 to add, 1 to change, 0 to destroy.         
module.secrets["RANDOM_SECRET"].random_password.secret[0]: Creating...
module.secrets["RANDOM_SECRET"].random_password.secret[0]: Creation complete after 0s [id=none]
module.secrets["RANDOM_SECRET"].azurerm_key_vault_secret.secret[0]: Creating...
module.secrets["RANDOM_SECRET"].azurerm_key_vault_secret.secret[0]: Creation complete after 4s [id=https://app-dev-eastus-938b915e7.vault.azure.net/secrets/random-secret/6540298961d74df9b1f7d387496a9b9b]
module.service.azurerm_role_assignment.migrator_secrets["SECRET_SAUCE"]: Creating...
module.service.azurerm_role_assignment.migrator_secrets["RANDOM_SECRET"]: Creating...
module.service.azurerm_role_assignment.migrator_secrets["SECRET_SAUCE"]: Still creating... [10s elapsed]
module.service.azurerm_role_assignment.migrator_secrets["RANDOM_SECRET"]: Still creating... [10s elapsed]
module.service.azurerm_role_assignment.migrator_secrets["RANDOM_SECRET"]: Still creating... [20s elapsed]
module.service.azurerm_role_assignment.migrator_secrets["SECRET_SAUCE"]: Still creating... [20s elapsed]
module.service.azurerm_role_assignment.migrator_secrets["RANDOM_SECRET"]: Creation complete after 24s [id=/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-secrets/providers/Microsoft.Key
Vault/vaults/app-dev-eastus-938b915e7/secrets/random-secret/providers/Microsoft.Authorization/roleAssignments/37f555f3-62e2-90c7-23f5-0ff1c64a79bc]
module.service.azurerm_role_assignment.migrator_secrets["SECRET_SAUCE"]: Creation complete after 24s [id=/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-secrets/providers/Microsoft.KeyV
ault/vaults/app-dev-eastus-938b915e7/secrets/secret-sauce/providers/Microsoft.Authorization/roleAssignments/016d5a70-3deb-c562-79e4-f40bc9da10ac]
module.service.azurerm_container_app_job.service_job: Modifying... [id=/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.App/jobs/app-dev-job]
module.service.azurerm_container_app_job.service_job: Still modifying... [id=/subscriptions/92128910-eb17-4847-b677-...oviders/Microsoft.App/jobs/app-dev-job, 10s elapsed]
module.service.azurerm_container_app_job.service_job: Modifications complete after 18s [id=/subscriptions/92128910-eb17-4847-b677-0f1110527d2b/resourceGroups/app-dev-service/providers/Microsoft.App/jobs/app-dev-j
ob]

[...]

Apply complete! Resources: 4 added, 1 changed, 0 destroyed.

Outputs:

image_tag = "a4963934bdb12245effab989d985563711b6c41e"
migrator_user_client_id = "65fb09c6-1127-450c-a354-b98ae8c496f6"
migrator_username = "app-dev-db-migrator"
service_endpoint = "https://app.dev.platform-test-azure.navateam.com"
service_job_name = "app-dev-job"
service_resource_group = "app-dev-service"

```
